### PR TITLE
[#9] Pull Request, Issue 이벤트를 Slack 으로 알리는 github actions 설정 추가

### DIFF
--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -1,0 +1,37 @@
+on:
+  pull_request:
+    types: [ opened, closed, reopened ]
+  issues:
+    types: [ opened, deleted, closed, reopened ]
+name: Slack Notification
+jobs:
+  pullRequestNotification:
+    if: ${{ github.event_name == 'pull_request'}}
+    name: Pull Request Event Notification
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: noti_pull_requests
+          SLACK_COLOR: good
+          SLACK_TITLE: PR ${{ github.event.pull_request.state }}
+          SLACK_MESSAGE: ${{ github.event.pull_request.title }}
+          SLACK_USERNAME: Pull Request 알리미
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_PR }}
+  issuesNotification:
+    if: ${{ github.event_name == 'issues'}}
+    name: Pull Request Review Event Notification
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: noti_issues
+          SLACK_COLOR: good
+          SLACK_TITLE: ISSUE ${{ github.event.issue.state }}
+          SLACK_MESSAGE: ${{ github.event.issue.title }}
+          SLACK_USERNAME: Issue 알리미
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_ISSUE }}


### PR DESCRIPTION
이슈나 PR 이 발생하면 빠르게 확인할 수 있도록 아래 채널에 알림을 발송하도록 했음

**#noti_pull_requests**
- PR Opened
- PR Closed
- PR Re-Opened

**#noti_issues**
- Issue Opened
- Issue Closed
- Issue Deleted
- Issue Re-Opened

--
PR 알림은 지금도 확인이 가능한데, Issue 는 main 브랜치에 merge 된 이후에 확인 가능한 듯함